### PR TITLE
Fix #6 remove unneeded curly braces

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,4 +43,4 @@ runs:
         "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${{ env.WORKFLOW_ID }}/runs?per_page=1&status=completed&branch=${{ env.BRANCH_NAME }}" \
         | jq -r .workflow_runs[0].conclusion)
         echo "Status of the previous build: $last_status"
-        echo "::set-output name=last_status::${last_status}"
+        echo "::set-output name=last_status::$last_status"


### PR DESCRIPTION
According to https://michaelcurrin.github.io/dev-cheatsheets/cheatsheets/ci-cd/github-actions/persist.html, use standard UNIX syntax $variable to set the output variable without curly braces around.