### PR TITLE
Change set-output call to storing variable in GITHUB_OUTPUT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,5 +42,5 @@ runs:
                                     --header 'content-type: application/json' \
         "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/${{ env.WORKFLOW_ID }}/runs?per_page=1&status=completed&branch=${{ env.BRANCH_NAME }}" \
         | jq -r .workflow_runs[0].conclusion)
-        echo "::set-output name=last_status::$last_status"
+        echo "last_status=$last_status" >> $GITHUB_OUTPUT
         echo "Status of the previous build: $last_status"


### PR DESCRIPTION
According to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ set-output call is deprecated and will be removed in the future. Environment files should be used instead of it.