### PR TITLE
use sed to avoid dependency on jq

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,8 @@ runs:
       run: |
         WORKFLOW_ID=$(curl --header 'authorization: Bearer ${{ inputs.github_token }}' \
                            --header 'content-type: application/json' \
-        ${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }} | jq -r .workflow_id)
+        ${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }} |
+          sed -E -ne 's/.*"workflow_id":\s*([0-9]+).*/\1/p')  # jq -r .workflow_id
         echo "WORKFLOW_ID=$WORKFLOW_ID" >> $GITHUB_ENV
         echo "Workflow id: ${WORKFLOW_ID}"
     - name: Get previous build status
@@ -40,7 +41,7 @@ runs:
       run: |
         last_status=$(curl --silent --header 'authorization: Bearer ${{ inputs.github_token }}' \
                                     --header 'content-type: application/json' \
-        "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/${{ env.WORKFLOW_ID }}/runs?per_page=1&status=completed&branch=${{ env.BRANCH_NAME }}" \
-        | jq -r .workflow_runs[0].conclusion)
+        "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/${{ env.WORKFLOW_ID }}/runs?per_page=1&status=completed&branch=${{ env.BRANCH_NAME }}" |
+          sed -E -ne '/"workflow_runs":/,/"conclusion":/ {s/.*"conclusion":\s*"([^"]*)".*/\1/p}')  # jq -r .workflow_runs[0].conclusion
         echo "last_status=$last_status" >> $GITHUB_OUTPUT
         echo "Status of the previous build: $last_status"


### PR DESCRIPTION
This is a fix for #17 (already closed).

I was initially detecting missing jq dependency and installing it it my workflow, but this PR avoids the dependency on jq by using sed instead.

# jq -r .workflow_id can be replaced by
sed -E -ne 's/.*"workflow_id":\s*([0-9]+).*/\1/p')

# jq -r .workflow_runs[0].conclusion can be replaced by
sed -E -ne '/"workflow_runs":/,/"conclusion":/ {s/.*"conclusion":\s*"([^"]*)".*/\1/p}')

Here the initial /"workflow_runs":/,/"conclusion":/ selects all lines from the start of the workflow_runs definition, and the rest gets the conclusion from the selected lines.
